### PR TITLE
feat(harness): --multi-session mode, pinned data dir across reps

### DIFF
--- a/harness/src/agent.ts
+++ b/harness/src/agent.ts
@@ -36,11 +36,21 @@ const AGENT_CMDS: Record<Variant, string> = {
 const DEFAULT_MAX_TURNS = Number(process.env["BENCH_MAX_TURNS"] ?? "30");
 const DEFAULT_TIMEOUT_MS = Number(process.env["BENCH_TIMEOUT_MS"] ?? String(20 * 60 * 1000));
 
+export interface RunAgentOptions {
+  /**
+   * If set, pin the adapter's XDG_DATA_HOME to this dir so Zengram state
+   * persists across reps. The adapter scripts recognise this via the env
+   * variable OPENCODE_PINNED_DATA_DIR (see scripts/run-zengram.sh).
+   */
+  pinnedDataDir?: string;
+}
+
 export async function runAgent(
   task: SweTask,
   variant: Variant,
   runIndex: number,
   repoDir: string,
+  agentOpts: RunAgentOptions = {},
 ): Promise<RunResult> {
   const cmd = AGENT_CMDS[variant];
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "zengram-bench-"));
@@ -51,6 +61,13 @@ export async function runAgent(
 
   const timestamp = new Date().toISOString();
   const start = Date.now();
+
+  const childEnv = {
+    ...process.env,
+    ...(agentOpts.pinnedDataDir
+      ? { OPENCODE_PINNED_DATA_DIR: agentOpts.pinnedDataDir }
+      : {}),
+  };
 
   try {
     await execFileAsync(
@@ -63,7 +80,7 @@ export async function runAgent(
         "--output-patch",     patchFile,
         "--usage-json",       usageFile,
       ],
-      { timeout: DEFAULT_TIMEOUT_MS },
+      { timeout: DEFAULT_TIMEOUT_MS, env: childEnv },
     );
 
     const duration_ms = Date.now() - start;

--- a/harness/src/index.ts
+++ b/harness/src/index.ts
@@ -40,6 +40,11 @@ program
   .option("--concurrency <n>", "number of tasks to run in parallel", "1")
   .option("--dry-run", "print what would run without invoking agents", false)
   .option("--skip-disk-check", "skip the free-disk-space preflight check", false)
+  .option(
+    "--multi-session",
+    "persist Zengram state across reps of the same (task, variant) so runs 2+ can recall from run 1 — measures compounding value",
+    false,
+  )
   .action(async (opts) => {
     const variants = (opts.variants as string)
       .split(",")
@@ -61,6 +66,7 @@ program
       taskFilter,
       concurrency,
       dryRun: opts.dryRun as boolean,
+      multiSession: opts.multiSession as boolean,
     });
   });
 

--- a/harness/src/run.ts
+++ b/harness/src/run.ts
@@ -33,7 +33,16 @@ export interface RunOptions {
   taskFilter?: string[];
   dryRun?: boolean;
   concurrency: number;
+  /**
+   * Multi-session mode: reps of the same (task, variant) share a persistent
+   * XDG_DATA_HOME so Zengram state accumulates across runs. Surfaces the
+   * compounding-value dimension of Zengram (B1 in zengram-elevation-plan.md);
+   * turn-count reduction in rep 2+ vs rep 0 is the thesis test.
+   */
+  multiSession?: boolean;
 }
+
+const MULTI_SESSION_ROOT = path.join(ROOT, "results", "multi-session-state");
 
 export async function runBenchmark(opts: RunOptions): Promise<void> {
   fs.mkdirSync(RESULTS_DIR, { recursive: true });
@@ -55,36 +64,49 @@ export async function runBenchmark(opts: RunOptions): Promise<void> {
     return;
   }
 
-  // Each work item is one (task, variant, runIdx) triple.
-  type WorkItem = { task: SweTask; variant: Variant; runIdx: number; label: string };
-  const queue: WorkItem[] = [];
+  // Group work by (task, variant) so reps run serially within a group
+  // (Zengram state accumulates across reps in multi-session mode, and even
+  // in single-session mode same-group reps race on temp dirs otherwise).
+  type Group = { task: SweTask; variant: Variant; reps: number };
+  const groups: Group[] = [];
   for (const task of tasks)
     for (const variant of opts.variants)
-      for (let runIdx = 0; runIdx < opts.numRuns; runIdx++)
-        queue.push({ task, variant, runIdx, label: `${task.task_id} ${variant} #${runIdx}` });
+      groups.push({ task, variant, reps: opts.numRuns });
 
   let completed = 0;
   const sem = new Semaphore(opts.concurrency);
 
   await Promise.all(
-    queue.map(async ({ task, variant, runIdx, label }) => {
-      const outPath = resultPath(task.task_id, variant, runIdx);
-      if (fs.existsSync(outPath)) {
-        console.log(`  [${++completed}/${total}] ${label} — skipped (exists)`);
-        return;
-      }
-
+    groups.map(async ({ task, variant, reps }) => {
       await sem.acquire();
-      console.log(`  [${++completed}/${total}] ${label} …`);
-      const repoDir = await setupRepo(task);
+      const pinnedDataDir = opts.multiSession
+        ? ensureMultiSessionDir(task.task_id, variant)
+        : undefined;
+
       try {
-        const result = await runAgent(task, variant, runIdx, repoDir);
-        writeResult(result, outPath);
-        const icon = result.status === "completed" ? "✓" : "✗";
-        const tokens = result.prompt_tokens + result.completion_tokens;
-        console.log(`  ${icon} ${label} — ${result.status} (${result.turns} turns, ${tokens} tok)`);
+        for (let runIdx = 0; runIdx < reps; runIdx++) {
+          const label = `${task.task_id} ${variant} #${runIdx}`;
+          const outPath = resultPath(task.task_id, variant, runIdx);
+          if (fs.existsSync(outPath)) {
+            console.log(`  [${++completed}/${total}] ${label} — skipped (exists)`);
+            continue;
+          }
+
+          console.log(`  [${++completed}/${total}] ${label} …`);
+          const repoDir = await setupRepo(task);
+          try {
+            const result = await runAgent(task, variant, runIdx, repoDir, {
+              pinnedDataDir,
+            });
+            writeResult(result, outPath);
+            const icon = result.status === "completed" ? "✓" : "✗";
+            const tokens = result.prompt_tokens + result.completion_tokens;
+            console.log(`  ${icon} ${label} — ${result.status} (${result.turns} turns, ${tokens} tok)`);
+          } finally {
+            fs.rmSync(repoDir, { recursive: true, force: true });
+          }
+        }
       } finally {
-        fs.rmSync(repoDir, { recursive: true, force: true });
         sem.release();
       }
     }),
@@ -92,6 +114,19 @@ export async function runBenchmark(opts: RunOptions): Promise<void> {
 
   console.log(`\nDone. Results written to ${RESULTS_DIR}`);
   console.log(`Next: cd harness/scorer && python score.py`);
+}
+
+// ── Multi-session state ──────────────────────────────────────────────────────
+//
+// Each (task, variant) pair gets its own persistent dir so reps 2+ can read
+// Zengram knowledge/workspace state from rep 0's writes. Pinned dirs stick
+// around across harness invocations so you can keep adding reps; if you need
+// a fresh start, delete `results/multi-session-state/` and re-run.
+
+function ensureMultiSessionDir(taskId: string, variant: Variant): string {
+  const dir = path.join(MULTI_SESSION_ROOT, `${taskId}_${variant}`);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
 }
 
 // ── Repo setup (with shared clone cache) ─────────────────────────────────────
@@ -112,7 +147,7 @@ async function ensureCache(repo: string): Promise<string> {
         fs.mkdirSync(path.dirname(cacheDir), { recursive: true });
         console.log(`    [cache] cloning ${repo} …`);
         await execFileAsync("git", [
-          "clone", "--bare", "--filter=blob:none",
+          "clone", "--bare",
           `https://github.com/${repo}.git`, cacheDir,
         ]);
       } else {

--- a/harness/src/run.ts
+++ b/harness/src/run.ts
@@ -64,27 +64,48 @@ export async function runBenchmark(opts: RunOptions): Promise<void> {
     return;
   }
 
-  // Group work by (task, variant) so reps run serially within a group
-  // (Zengram state accumulates across reps in multi-session mode, and even
-  // in single-session mode same-group reps race on temp dirs otherwise).
-  type Group = { task: SweTask; variant: Variant; reps: number };
-  const groups: Group[] = [];
-  for (const task of tasks)
-    for (const variant of opts.variants)
-      groups.push({ task, variant, reps: opts.numRuns });
+  // Multi-session mode REQUIRES reps of the same (task, variant) to run
+  // serially — Zengram state accumulates rep-to-rep and concurrent writes
+  // would race. In single-session mode there's no such constraint: each rep
+  // uses its own temp dir, so we preserve the prior behavior of treating
+  // each rep as a separate work item bounded by `--concurrency`.
+  type WorkItem = {
+    task: SweTask;
+    variant: Variant;
+    reps: Array<{ runIdx: number }>; // always 1 in single-session, N in multi-session
+    pinnedDataDir: string | undefined;
+  };
+  const items: WorkItem[] = [];
+  for (const task of tasks) {
+    for (const variant of opts.variants) {
+      // Only the Zengram fork reads OPENCODE_PINNED_DATA_DIR; baseline runs
+      // ignore it, so there's no reason to allocate a dir on disk for them.
+      const pinnedDataDir =
+        opts.multiSession && variant === "zengram"
+          ? ensureMultiSessionDir(task.task_id, variant)
+          : undefined;
+      if (opts.multiSession && pinnedDataDir) {
+        items.push({
+          task,
+          variant,
+          reps: Array.from({ length: opts.numRuns }, (_, runIdx) => ({ runIdx })),
+          pinnedDataDir,
+        });
+      } else {
+        for (let runIdx = 0; runIdx < opts.numRuns; runIdx++)
+          items.push({ task, variant, reps: [{ runIdx }], pinnedDataDir: undefined });
+      }
+    }
+  }
 
   let completed = 0;
   const sem = new Semaphore(opts.concurrency);
 
   await Promise.all(
-    groups.map(async ({ task, variant, reps }) => {
+    items.map(async ({ task, variant, reps, pinnedDataDir }) => {
       await sem.acquire();
-      const pinnedDataDir = opts.multiSession
-        ? ensureMultiSessionDir(task.task_id, variant)
-        : undefined;
-
       try {
-        for (let runIdx = 0; runIdx < reps; runIdx++) {
+        for (const { runIdx } of reps) {
           const label = `${task.task_id} ${variant} #${runIdx}`;
           const outPath = resultPath(task.task_id, variant, runIdx);
           if (fs.existsSync(outPath)) {
@@ -123,8 +144,24 @@ export async function runBenchmark(opts: RunOptions): Promise<void> {
 // around across harness invocations so you can keep adding reps; if you need
 // a fresh start, delete `results/multi-session-state/` and re-run.
 
+/**
+ * Sanitize a value for use as a filesystem path segment. Task IDs are loaded
+ * from an external tasks.json, so they can in principle contain `..`,
+ * forward/back slashes, NUL bytes, etc. Replace anything outside
+ * `[A-Za-z0-9._-]` with `_` so the resulting segment can't escape the root
+ * or produce an invalid directory name.
+ */
+function toSafePathSlug(value: string): string {
+  const slug = value.replace(/[^A-Za-z0-9._-]/g, "_");
+  return slug.length > 0 ? slug : "_";
+}
+
 function ensureMultiSessionDir(taskId: string, variant: Variant): string {
-  const dir = path.join(MULTI_SESSION_ROOT, `${taskId}_${variant}`);
+  const dir = path.resolve(MULTI_SESSION_ROOT, `${toSafePathSlug(taskId)}_${toSafePathSlug(String(variant))}`);
+  const relative = path.relative(MULTI_SESSION_ROOT, dir);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`Resolved multi-session dir escapes root: ${dir}`);
+  }
   fs.mkdirSync(dir, { recursive: true });
   return dir;
 }

--- a/scripts/run-baseline.sh
+++ b/scripts/run-baseline.sh
@@ -59,9 +59,30 @@ run_once() {
     }
 }
 
+# Whitespace-tolerant step_finish detection — substring grep for
+# `"type":"step_finish"` misses lines whose formatter emits spaces, causing
+# spurious 90 s retries.
+has_step_finish() {
+  python3 - "$1" <<'PY'
+import json, sys
+with open(sys.argv[1], "r", errors="replace") as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            evt = json.loads(line)
+        except Exception:
+            continue
+        if evt.get("type") == "step_finish":
+            sys.exit(0)
+sys.exit(1)
+PY
+}
+
 run_once
 # If no step_finish events were produced, assume rate-limiting and retry once.
-if ! grep -q '"type":"step_finish"' "$EVENTS_FILE"; then
+if ! has_step_finish "$EVENTS_FILE"; then
   echo "[adapter] no step_finish events — waiting 90 s then retrying once" >&2
   sleep 90
   run_once

--- a/scripts/run-baseline.sh
+++ b/scripts/run-baseline.sh
@@ -33,7 +33,10 @@ done
 
 OPENCODE_BIN="${OPENCODE_BIN:-opencode}"
 EVENTS_FILE=$(mktemp /tmp/opencode-events-XXXXXX.jsonl)
-trap 'rm -f "$EVENTS_FILE"' EXIT
+# Each run gets its own XDG_DATA_HOME so SQLite and any cached state are
+# isolated — prevents cross-run corruption from crashes or interrupts.
+RUN_DATA_DIR=$(mktemp -d /tmp/opencode-baseline-data-XXXXXX)
+trap 'rm -f "$EVENTS_FILE"; rm -rf "$RUN_DATA_DIR"' EXIT
 
 # ── Inject max-steps into agent config via env var ───────────────────────────
 # OPENCODE_CONFIG_CONTENT is merged over file-based config at startup.
@@ -44,36 +47,54 @@ OPENCODE_CONFIG_CONTENT=$(printf '{"agent":{"build":{"steps":%d}}}' "$TURNS")
 # ── Run OpenCode (baseline = SQLite, no Zengram) ─────────────────────────────
 # Pipe problem statement via stdin — avoids shell-quoting issues for large prompts.
 # OPENCODE_STORAGE=sqlite disables the Zengram storage layer in the fork.
-OPENCODE_STORAGE=sqlite "$OPENCODE_BIN" run \
-  --format json \
-  --dir    "$REPO" \
-  < "$PROBLEM" > "$EVENTS_FILE" 2>&1 || {
-    echo "[adapter] opencode exited non-zero, capturing partial results" >&2
-  }
+# Retry once after 90 s if the run produces 0 step_finish events (rate limit).
+run_once() {
+  : > "$EVENTS_FILE"
+  rm -rf "$RUN_DATA_DIR" && mkdir -p "$RUN_DATA_DIR"
+  XDG_DATA_HOME="$RUN_DATA_DIR" OPENCODE_STORAGE=sqlite "$OPENCODE_BIN" run \
+    --format json \
+    --dir    "$REPO" \
+    < "$PROBLEM" > "$EVENTS_FILE" 2>&1 || {
+      echo "[adapter] opencode exited non-zero, capturing partial results" >&2
+    }
+}
+
+run_once
+# If no step_finish events were produced, assume rate-limiting and retry once.
+if ! grep -q '"type":"step_finish"' "$EVENTS_FILE"; then
+  echo "[adapter] no step_finish events — waiting 90 s then retrying once" >&2
+  sleep 90
+  run_once
+fi
 
 # ── Capture diff ─────────────────────────────────────────────────────────────
 git -C "$REPO" diff HEAD > "$PATCH"
 
 # ── Extract token totals from step_finish events ─────────────────────────────
 # Each step_finish JSON line has: { type:"step_finish", part:{ tokens:{input,output,...} } }
-node --input-type=module <<JS
-import fs from 'node:fs';
-const raw = fs.readFileSync('${EVENTS_FILE}', 'utf8');
-let turns = 0, promptTok = 0, completionTok = 0;
-for (const line of raw.split('\n')) {
-  if (!line.trim()) continue;
-  try {
-    const evt = JSON.parse(line);
-    if (evt.type === 'step_finish') {
-      turns++;
-      promptTok     += Number(evt.part?.tokens?.input  ?? 0);
-      completionTok += Number(evt.part?.tokens?.output ?? 0);
-    }
-  } catch { /* skip non-JSON lines (stderr mixed in) */ }
-}
-fs.writeFileSync('${USAGE}', JSON.stringify({
-  turns,
-  prompt_tokens: promptTok,
-  completion_tokens: completionTok,
-}));
-JS
+python3 - "$EVENTS_FILE" "$USAGE" <<'PY'
+import sys, json
+
+events_file, usage_file = sys.argv[1], sys.argv[2]
+turns = 0
+prompt_tok = 0
+completion_tok = 0
+
+with open(events_file, "r", errors="replace") as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            evt = json.loads(line)
+        except Exception:
+            continue
+        if evt.get("type") == "step_finish":
+            turns += 1
+            tok = (evt.get("part") or {}).get("tokens") or {}
+            prompt_tok     += tok.get("input",  0)
+            completion_tok += tok.get("output", 0)
+
+with open(usage_file, "w") as f:
+    json.dump({"turns": turns, "prompt_tokens": prompt_tok, "completion_tokens": completion_tok}, f)
+PY

--- a/scripts/run-zengram.sh
+++ b/scripts/run-zengram.sh
@@ -72,9 +72,30 @@ run_once() {
     }
 }
 
+# Whitespace-tolerant step_finish detection — substring grep for
+# `"type":"step_finish"` misses lines whose formatter emits spaces
+# (e.g. `"type": "step_finish"`), triggering a spurious 90 s retry.
+has_step_finish() {
+  python3 - "$1" <<'PY'
+import json, sys
+with open(sys.argv[1], "r", errors="replace") as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            evt = json.loads(line)
+        except Exception:
+            continue
+        if evt.get("type") == "step_finish":
+            sys.exit(0)
+sys.exit(1)
+PY
+}
+
 run_once
 # If no step_finish events were produced, assume rate-limiting and retry once.
-if ! grep -q '"type":"step_finish"' "$EVENTS_FILE"; then
+if ! has_step_finish "$EVENTS_FILE"; then
   echo "[adapter] no step_finish events — waiting 90 s then retrying once" >&2
   sleep 90
   run_once

--- a/scripts/run-zengram.sh
+++ b/scripts/run-zengram.sh
@@ -34,7 +34,19 @@ done
 
 OPENCODE_ZENGRAM_BIN="${OPENCODE_ZENGRAM_BIN:-opencode}"
 EVENTS_FILE=$(mktemp /tmp/opencode-zengram-events-XXXXXX.jsonl)
-trap 'rm -f "$EVENTS_FILE"' EXIT
+
+# OPENCODE_PINNED_DATA_DIR — when set, reuse this XDG_DATA_HOME across runs
+# (multi-session mode: Zengram state accumulates so recall has something to
+# return on the 2nd/3rd rep of the same task). When unset, allocate a fresh
+# dir per invocation (single-session mode, prior behavior).
+if [[ -n "${OPENCODE_PINNED_DATA_DIR:-}" ]]; then
+  RUN_DATA_DIR="$OPENCODE_PINNED_DATA_DIR"
+  mkdir -p "$RUN_DATA_DIR"
+  trap 'rm -f "$EVENTS_FILE"' EXIT  # preserve data dir for next rep
+else
+  RUN_DATA_DIR=$(mktemp -d /tmp/opencode-zengram-data-XXXXXX)
+  trap 'rm -f "$EVENTS_FILE"; rm -rf "$RUN_DATA_DIR"' EXIT
+fi
 
 # ── Inject max-steps into agent config via env var ───────────────────────────
 export OPENCODE_CONFIG_CONTENT
@@ -43,12 +55,30 @@ OPENCODE_CONFIG_CONTENT=$(printf '{"agent":{"build":{"steps":%d}}}' "$TURNS")
 # ── Run OpenCode fork (Zengram storage enabled by default) ───────────────────
 # The fork writes every turn to Zengram as events arrive.  We also capture the
 # JSON event stream so we can extract token totals without querying the DB.
-"$OPENCODE_ZENGRAM_BIN" run \
-  --format json \
-  --dir    "$REPO" \
-  < "$PROBLEM" > "$EVENTS_FILE" 2>&1 || {
-    echo "[adapter] opencode-zengram exited non-zero, capturing partial results" >&2
-  }
+# Retry once after 90 s if the run produces 0 step_finish events (rate limit).
+run_once() {
+  : > "$EVENTS_FILE"
+  # Only wipe the data dir in single-session mode. Multi-session callers
+  # (OPENCODE_PINNED_DATA_DIR set) depend on Zengram state persisting across
+  # reps, so we must not nuke it between invocations.
+  if [[ -z "${OPENCODE_PINNED_DATA_DIR:-}" ]]; then
+    rm -rf "$RUN_DATA_DIR" && mkdir -p "$RUN_DATA_DIR"
+  fi
+  XDG_DATA_HOME="$RUN_DATA_DIR" "$OPENCODE_ZENGRAM_BIN" run \
+    --format json \
+    --dir    "$REPO" \
+    < "$PROBLEM" > "$EVENTS_FILE" 2>&1 || {
+      echo "[adapter] opencode-zengram exited non-zero, capturing partial results" >&2
+    }
+}
+
+run_once
+# If no step_finish events were produced, assume rate-limiting and retry once.
+if ! grep -q '"type":"step_finish"' "$EVENTS_FILE"; then
+  echo "[adapter] no step_finish events — waiting 90 s then retrying once" >&2
+  sleep 90
+  run_once
+fi
 
 # ── Capture diff ─────────────────────────────────────────────────────────────
 git -C "$REPO" diff HEAD > "$PATCH"
@@ -56,23 +86,35 @@ git -C "$REPO" diff HEAD > "$PATCH"
 # ── Extract token totals from step_finish events ─────────────────────────────
 # step_finish events carry: { type:"step_finish", sessionID, part:{ tokens:{input,output,...} } }
 # We also surface the Zengram session ID for downstream tracing.
-node --input-type=module <<JS
-import fs from 'node:fs';
-const raw = fs.readFileSync('${EVENTS_FILE}', 'utf8');
-let turns = 0, promptTok = 0, completionTok = 0, sessionID = null;
-for (const line of raw.split('\n')) {
-  if (!line.trim()) continue;
-  try {
-    const evt = JSON.parse(line);
-    if (evt.sessionID && !sessionID) sessionID = evt.sessionID;
-    if (evt.type === 'step_finish') {
-      turns++;
-      promptTok     += Number(evt.part?.tokens?.input  ?? 0);
-      completionTok += Number(evt.part?.tokens?.output ?? 0);
-    }
-  } catch { /* skip non-JSON lines */ }
-}
-const out = { turns, prompt_tokens: promptTok, completion_tokens: completionTok };
-if (sessionID) out.session_id = sessionID;
-fs.writeFileSync('${USAGE}', JSON.stringify(out));
-JS
+python3 - "$EVENTS_FILE" "$USAGE" <<'PY'
+import sys, json
+
+events_file, usage_file = sys.argv[1], sys.argv[2]
+turns = 0
+prompt_tok = 0
+completion_tok = 0
+session_id = None
+
+with open(events_file, "r", errors="replace") as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            evt = json.loads(line)
+        except Exception:
+            continue
+        if evt.get("sessionID") and not session_id:
+            session_id = evt["sessionID"]
+        if evt.get("type") == "step_finish":
+            turns += 1
+            tok = (evt.get("part") or {}).get("tokens") or {}
+            prompt_tok     += tok.get("input",  0)
+            completion_tok += tok.get("output", 0)
+
+out = {"turns": turns, "prompt_tokens": prompt_tok, "completion_tokens": completion_tok}
+if session_id:
+    out["session_id"] = session_id
+with open(usage_file, "w") as f:
+    json.dump(out, f)
+PY


### PR DESCRIPTION
## Summary

Adds \`--multi-session\` to \`bench run\`. When enabled, reps of the same (task, variant) share a persistent \`XDG_DATA_HOME\` so Zengram state accumulates from rep 0 → rep 1 → rep 2. Without this, each rep starts Zengram-empty and the compounding-value dimension of Zengram's design can't be measured.

## Why

Zengram's thesis is that persistent memory across sessions shortens exploration on related future sessions. The original benchmark runs each (task, variant) fresh, which inherently cannot surface that benefit. This flag gives us a direct test: does rep 2+ need fewer turns than rep 0?

## Changes

- \`harness/src/run.ts\`: group work by (task, variant), execute reps serially within each group in multi-session mode (state can't race). Per-group data dir lives under \`results/multi-session-state/<task>_<variant>/\` so it survives across harness invocations.
- \`harness/src/agent.ts\`: thread an optional \`pinnedDataDir\` through to the child via \`OPENCODE_PINNED_DATA_DIR\` env var.
- \`scripts/run-zengram.sh\`: recognise \`OPENCODE_PINNED_DATA_DIR\`. When set, reuse that XDG_DATA_HOME and skip the wipe + cleanup trap so Zengram data persists for the next rep.
- \`scripts/run-baseline.sh\`: isolated XDG_DATA_HOME + retry pattern, matching run-zengram.sh (was already needed).

## Usage

\`\`\`bash
# Single-session (old behavior):
bun run src/index.ts run --filter task_id --variants zengram --runs 3

# Multi-session (new):
bun run src/index.ts run --filter task_id --variants zengram --runs 3 --multi-session
\`\`\`

State accumulates in \`results/multi-session-state/<task>_<variant>/\`. Delete that dir for a clean start.

## First experiment (dj-11740, 3 reps)

| rep | turns | prompt_tok | duration | status |
|---|---|---|---|---|
| 0 | 26 | 29,896 | 131 s | ✓ |
| 1 | **30** | 26,168 | 261 s | ✓ |
| 2 | **30** | 34,449 | 229 s | ✓ |

**Verdict:** compounding-value thesis did NOT materialize on this task. Reps 1 and 2 hit the 30-turn cap instead of shortening. Token count is flat. Next: sample extracted facts for quality (B5 in \`opencode/specs/zengram-elevation-plan.md\`) to see whether the recall is actionable or distracting. The harness change itself is still worth landing — it's what makes any such experiment possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)