### PR TITLE
feat(harness): trajectory capture + wasted-action analyzer

### DIFF
--- a/harness/src/agent.ts
+++ b/harness/src/agent.ts
@@ -12,11 +12,15 @@
  *     --repo <dir> \
  *     --max-turns <n> \
  *     --output-patch <file> \
- *     --usage-json <file>
+ *     --usage-json <file> \
+ *     --trajectory-json <file>   (optional; adapter may ignore)
  *
  * The command must exit 0 on success. It writes:
- *   <output-patch>  unified diff of changes made to the repo
- *   <usage-json>    { turns, prompt_tokens, completion_tokens }
+ *   <output-patch>      unified diff of changes made to the repo
+ *   <usage-json>        { turns, prompt_tokens, completion_tokens, ... }
+ *   <trajectory-json>   { tool_counts, files_touched, bash_commands, records }
+ *                       (optional — adapters that don't write it cause
+ *                       RunResult.trajectory to stay undefined)
  */
 
 import { execFile } from "node:child_process";
@@ -24,7 +28,7 @@ import { promisify } from "node:util";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { RunResult, SweTask, Variant } from "./types.js";
+import type { RunResult, SweTask, Trajectory, Variant } from "./types.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -56,8 +60,31 @@ export async function runAgent(
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "zengram-bench-"));
   const patchFile = path.join(tmpDir, "output.patch");
   const usageFile = path.join(tmpDir, "usage.json");
+  const trajFile  = path.join(tmpDir, "trajectory.json");
   const problemFile = path.join(tmpDir, "problem.txt");
-  fs.writeFileSync(problemFile, task.problem_statement, "utf8");
+  // Optional SWE-bench preamble — frames the task as "produce a patch" rather
+  // than a Q&A. Strong frontier models infer this from the system prompt;
+  // smaller open models (e.g. Qwen3-Coder-30B-A3B) often need it explicit.
+  // Toggle with BENCH_PREAMBLE=1 to keep prior baselines untouched.
+  const preamble = process.env["BENCH_PREAMBLE"] === "1"
+    ? `You are a software engineer working inside the project's own source-code checkout. The current working directory IS the project repository — for example, if the bug is in Django's migrations system, the file you need to edit is something like ./django/db/migrations/autodetector.py, not a new file you create.
+
+Rules:
+1. The bug is in EXISTING source files. Find the relevant tracked file with grep/glob/read tools, then edit it in place with the edit tool.
+2. Do NOT create new files. Do NOT scaffold a sample project (no manage.py, no settings.py, no testapp/, no reproduction harness). The repository at cwd already contains the buggy code.
+3. Do NOT modify any file under tests/ or *_test.py — only edit production source.
+4. Do NOT explain the behavior in prose; the user wants a fix, not an explanation.
+5. You MUST call the edit (or write) tool to actually modify the file. Reading the file, globbing, or seeing a hint in a <zengram-previously-helpful> block is NOT making an edit — only an edit/write tool call counts.
+6. Stop IMMEDIATELY after the edit/write tool call succeeds. Do not run 'git diff' to verify, do not re-read the file, do not run tests, do not explain what you did. The bench harness verifies the patch externally — your job ends the moment the edit lands.
+7. If a <zengram-previously-helpful> block tells you the file and shows the working change, use it as a shortcut: read the file ONCE for context, then call the edit tool with the equivalent change. Do not re-discover the fix from scratch — but you DO still have to call the edit tool.
+8. CRITICAL: a <zengram-previously-helpful> block describes what worked in PRIOR sessions. Those edits DO NOT exist in the current checkout — every session starts from an unmodified clean checkout. The play is a HINT, not evidence the file is already fixed. You MUST call edit/write yourself in this session, even if the play looks like the answer. Ending the session without an edit/write tool call is a failure regardless of what the play shows.
+9. KNOW WHEN TO QUIT. If after ~8 turns of exploration you cannot identify a concrete file and a concrete edit to make, write one short message saying "I cannot determine a fix for this issue" and stop. Spending all 15 turns reading and grepping without ever editing is strictly worse than admitting defeat at turn 8 — it wastes tokens and produces the same null result. Failing fast is success when the alternative is failing slow.
+
+---
+
+`
+    : "";
+  fs.writeFileSync(problemFile, preamble + task.problem_statement, "utf8");
 
   const timestamp = new Date().toISOString();
   const start = Date.now();
@@ -79,6 +106,7 @@ export async function runAgent(
         "--max-turns",        String(DEFAULT_MAX_TURNS),
         "--output-patch",     patchFile,
         "--usage-json",       usageFile,
+        "--trajectory-json",  trajFile,
       ],
       { timeout: DEFAULT_TIMEOUT_MS, env: childEnv },
     );
@@ -92,38 +120,51 @@ export async function runAgent(
           turns: number;
           prompt_tokens: number;
           completion_tokens: number;
+          cache_read_tokens?: number;
+          turns_with_cache_hit?: number;
           session_id?: string;
         })
       : { turns: 0, prompt_tokens: 0, completion_tokens: 0 };
+    // Trajectory file is optional — older adapters that ignore the
+    // --trajectory-json flag won't produce one. Missing trajectory is fine;
+    // unparseable trajectory is a real bug — let it surface rather than mask it.
+    const trajectory: Trajectory | undefined = fs.existsSync(trajFile)
+      ? (JSON.parse(fs.readFileSync(trajFile, "utf8")) as Trajectory)
+      : undefined;
 
     return {
-      task_id:           task.task_id,
+      task_id:              task.task_id,
       variant,
-      run_index:         runIndex,
+      run_index:            runIndex,
       timestamp,
-      status:            "completed",
+      status:               "completed",
       patch,
-      turns:             usage.turns,
-      prompt_tokens:     usage.prompt_tokens,
-      completion_tokens: usage.completion_tokens,
+      turns:                usage.turns,
+      prompt_tokens:        usage.prompt_tokens,
+      completion_tokens:    usage.completion_tokens,
+      cache_read_tokens:    usage.cache_read_tokens ?? 0,
+      turns_with_cache_hit: usage.turns_with_cache_hit ?? 0,
       duration_ms,
       ...(usage.session_id ? { session_id: usage.session_id } : {}),
+      ...(trajectory ? { trajectory } : {}),
     };
   } catch (err: unknown) {
     const duration_ms = Date.now() - start;
     const isTimeout = err instanceof Error && err.message.includes("ETIMEDOUT");
     return {
-      task_id:           task.task_id,
+      task_id:              task.task_id,
       variant,
-      run_index:         runIndex,
+      run_index:            runIndex,
       timestamp,
-      status:            isTimeout ? "timeout" : "failed",
-      patch:             "",
-      turns:             0,
-      prompt_tokens:     0,
-      completion_tokens: 0,
+      status:               isTimeout ? "timeout" : "failed",
+      patch:                "",
+      turns:                0,
+      prompt_tokens:        0,
+      completion_tokens:    0,
+      cache_read_tokens:    0,
+      turns_with_cache_hit: 0,
       duration_ms,
-      error:             err instanceof Error ? err.message : String(err),
+      error:                err instanceof Error ? err.message : String(err),
     };
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/harness/src/analyze.ts
+++ b/harness/src/analyze.ts
@@ -1,0 +1,360 @@
+/**
+ * Trajectory analyzer — classifies each tool call into a wasted-action bucket
+ * and surfaces aggregates per variant.
+ *
+ * Reads:
+ *   results/runs/*.json    (RunResult — must include `trajectory`)
+ *   results/scores/*.json  (ScoreResult — to know resolved/unresolved)
+ *
+ * Writes:
+ *   results/analysis.json  (per-run tagged records + aggregate)
+ *
+ * North-star metric: resolved_per_million_tokens = 1e6 × resolved / total_tokens.
+ * Optimize this. Higher is better. Wasted-action buckets feed back into which
+ * heuristic to attack first.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type {
+  RunResult,
+  ScoreResult,
+  ToolCallRecord,
+  Trajectory,
+  Variant,
+} from "./types.js";
+
+const ROOT = path.resolve(fileURLToPath(import.meta.url), "../../..");
+const RUNS_DIR     = path.join(ROOT, "results", "runs");
+const SCORES_DIR   = path.join(ROOT, "results", "scores");
+const ANALYSIS_OUT = path.join(ROOT, "results", "analysis.json");
+
+/** Per-call waste tag. "useful" is the catch-all for non-flagged calls. */
+export type WasteTag =
+  | "useful"
+  | "redundant_read"   // same file read 2+ times in this run (chunked reads conflated, see note)
+  | "premature_test"   // bash test runner ran before any edit/write landed
+  | "lint_only"        // bash matched a formatter/linter, not a test
+  | "error_retry";     // this call retried a same-tool same-input call that errored
+
+/** Run-level pattern flags (orthogonal to per-call tags). */
+export type RunFlag =
+  | "no_edit"          // session ended without ever editing — pure exploration
+  | "high_redundancy"; // > 30% of reads were redundant
+
+export interface TaggedRecord extends ToolCallRecord {
+  tag: WasteTag;
+}
+
+export interface RunAnalysis {
+  task_id: string;
+  variant: Variant;
+  run_index: number;
+  resolved: boolean;
+  turns: number;
+  total_tokens: number;
+  tag_counts: Record<WasteTag, number>;
+  run_flags: RunFlag[];
+  tagged_records: TaggedRecord[];
+}
+
+export interface VariantAggregate {
+  variant: Variant;
+  n_runs: number;
+  n_resolved: number;
+  resolution_rate: number;
+  total_tokens: number;
+  resolved_per_million_tokens: number;     // <- the north star
+  median_total_tokens: number;
+  median_turns: number;
+  tag_distribution: Record<WasteTag, number>;
+  tag_share: Record<WasteTag, number>;     // tag_distribution normalised to fractions
+  run_flag_counts: Record<RunFlag, number>;
+  top_redundant_files: Array<{ path: string; redundant_reads: number; runs: number }>;
+}
+
+export interface Analysis {
+  generated_at: string;
+  per_run: RunAnalysis[];
+  by_variant: Record<Variant, VariantAggregate>;
+}
+
+// ── Heuristic patterns ───────────────────────────────────────────────────────
+//
+// Test-runner detection: only the `cmd=...` substring of input_summary is
+// matched (set by the adapter for tool=bash). Patterns are deliberately broad
+// — false positives here label non-test bash as `premature_test`, but every
+// project has its own incantation. Tune against bench data.
+const TEST_RUNNER_PATTERNS = [
+  /\bpytest\b/,
+  /python\s+-m\s+pytest\b/,
+  /python\s+manage\.py\s+test\b/,
+  /\brunte?sts?\.py\b/,
+  /\bbun\s+test\b/,
+  /\bnpm\s+(?:run\s+)?test\b/,
+  /\bjest\b/,
+  /\bvitest\b/,
+  /\bgo\s+test\b/,
+];
+
+const LINT_PATTERNS = [
+  /\bblack\b/,
+  /\bruff\b/,
+  /\bflake8\b/,
+  /\bmypy\b/,
+  /\bpylint\b/,
+  /\beslint\b/,
+  /\bprettier\b/,
+];
+
+// ── Per-run classification ───────────────────────────────────────────────────
+
+function classifyRecords(records: ToolCallRecord[]): TaggedRecord[] {
+  const seenReadPaths = new Set<string>();
+  let firstEditIdx = records.findIndex(
+    (r) => (r.tool === "edit" || r.tool === "write") && r.status === "completed",
+  );
+  if (firstEditIdx === -1) firstEditIdx = Number.POSITIVE_INFINITY;
+
+  const tagged: TaggedRecord[] = [];
+  for (let i = 0; i < records.length; i++) {
+    const r = records[i]!;
+    let tag: WasteTag = "useful";
+
+    if (r.tool === "read") {
+      // input_summary is `path=<file>`; group by exact summary so we don't
+      // need to re-parse. Chunked reads of the same file (different offsets)
+      // get conflated — flagged in the type doc above.
+      if (seenReadPaths.has(r.input_summary)) tag = "redundant_read";
+      else seenReadPaths.add(r.input_summary);
+    } else if (r.tool === "bash") {
+      const cmd = r.input_summary.startsWith("cmd=") ? r.input_summary.slice(4) : r.input_summary;
+      if (LINT_PATTERNS.some((p) => p.test(cmd))) tag = "lint_only";
+      else if (TEST_RUNNER_PATTERNS.some((p) => p.test(cmd)) && i < firstEditIdx) tag = "premature_test";
+    }
+
+    // error_retry overrides the above: if the *previous* record errored on
+    // the same tool with same input_summary, this record is a retry.
+    if (i > 0) {
+      const prev = records[i - 1]!;
+      if (prev.status === "error" && prev.tool === r.tool && prev.input_summary === r.input_summary) {
+        tag = "error_retry";
+      }
+    }
+
+    tagged.push({ ...r, tag });
+  }
+  return tagged;
+}
+
+function deriveRunFlags(tagged: TaggedRecord[]): RunFlag[] {
+  const flags: RunFlag[] = [];
+  const edits = tagged.filter((r) => (r.tool === "edit" || r.tool === "write") && r.status === "completed");
+  if (edits.length === 0) flags.push("no_edit");
+
+  const reads = tagged.filter((r) => r.tool === "read");
+  const redundant = reads.filter((r) => r.tag === "redundant_read");
+  if (reads.length >= 3 && redundant.length / reads.length > 0.3) flags.push("high_redundancy");
+
+  return flags;
+}
+
+function emptyTagCounts(): Record<WasteTag, number> {
+  return {
+    useful: 0,
+    redundant_read: 0,
+    premature_test: 0,
+    lint_only: 0,
+    error_retry: 0,
+  };
+}
+
+function emptyFlagCounts(): Record<RunFlag, number> {
+  return { no_edit: 0, high_redundancy: 0 };
+}
+
+function analyzeRun(run: RunResult, score: ScoreResult | undefined): RunAnalysis | null {
+  const traj: Trajectory | undefined = run.trajectory;
+  if (!traj) return null; // skip pre-instrumentation runs silently
+
+  const tagged = classifyRecords(traj.records);
+  const tag_counts = emptyTagCounts();
+  for (const r of tagged) tag_counts[r.tag]++;
+
+  return {
+    task_id: run.task_id,
+    variant: run.variant,
+    run_index: run.run_index,
+    resolved: score?.resolved ?? false,
+    turns: run.turns,
+    total_tokens: run.prompt_tokens + run.completion_tokens,
+    tag_counts,
+    run_flags: deriveRunFlags(tagged),
+    tagged_records: tagged,
+  };
+}
+
+// ── Aggregate ────────────────────────────────────────────────────────────────
+
+function aggregate(variant: Variant, runs: RunAnalysis[]): VariantAggregate {
+  const mine = runs.filter((r) => r.variant === variant);
+  const n_runs = mine.length;
+  const n_resolved = mine.filter((r) => r.resolved).length;
+  const total_tokens = mine.reduce((acc, r) => acc + r.total_tokens, 0);
+
+  const tag_distribution = emptyTagCounts();
+  for (const r of mine) {
+    for (const k of Object.keys(r.tag_counts) as WasteTag[]) {
+      tag_distribution[k] += r.tag_counts[k];
+    }
+  }
+  const total_calls = (Object.values(tag_distribution) as number[]).reduce((a, b) => a + b, 0);
+  const tag_share = emptyTagCounts() as unknown as Record<WasteTag, number>;
+  if (total_calls > 0) {
+    for (const k of Object.keys(tag_distribution) as WasteTag[]) {
+      tag_share[k] = tag_distribution[k] / total_calls;
+    }
+  }
+
+  const run_flag_counts = emptyFlagCounts();
+  for (const r of mine) {
+    for (const f of r.run_flags) run_flag_counts[f]++;
+  }
+
+  // Top files redundantly re-read across runs. Aggregate redundant_read tags
+  // by file, count how many runs touched each.
+  const fileMap = new Map<string, { redundant_reads: number; runs: Set<string> }>();
+  for (const r of mine) {
+    for (const tr of r.tagged_records) {
+      if (tr.tag !== "redundant_read") continue;
+      const path = tr.input_summary.startsWith("path=") ? tr.input_summary.slice(5) : tr.input_summary;
+      const entry = fileMap.get(path) ?? { redundant_reads: 0, runs: new Set<string>() };
+      entry.redundant_reads++;
+      entry.runs.add(`${r.task_id}_${r.run_index}`);
+      fileMap.set(path, entry);
+    }
+  }
+  const top_redundant_files = [...fileMap.entries()]
+    .map(([p, v]) => ({ path: p, redundant_reads: v.redundant_reads, runs: v.runs.size }))
+    .sort((a, b) => b.redundant_reads - a.redundant_reads)
+    .slice(0, 10);
+
+  return {
+    variant,
+    n_runs,
+    n_resolved,
+    resolution_rate: n_runs > 0 ? n_resolved / n_runs : 0,
+    total_tokens,
+    resolved_per_million_tokens: total_tokens > 0 ? (n_resolved / total_tokens) * 1e6 : 0,
+    median_total_tokens: median(mine.map((r) => r.total_tokens)),
+    median_turns: median(mine.map((r) => r.turns)),
+    tag_distribution,
+    tag_share,
+    run_flag_counts,
+    top_redundant_files,
+  };
+}
+
+// ── Public entry points ──────────────────────────────────────────────────────
+
+export function buildAnalysis(): Analysis {
+  const runs   = loadJsonDir<RunResult>(RUNS_DIR);
+  const scores = loadJsonDir<ScoreResult>(SCORES_DIR);
+  const scoreKey = (s: { task_id: string; variant: string; run_index: number }) =>
+    `${s.task_id}|${s.variant}|${s.run_index}`;
+  const scoreByKey = new Map(scores.map((s) => [scoreKey(s), s]));
+
+  const per_run: RunAnalysis[] = [];
+  for (const run of runs) {
+    if (run.status !== "completed") continue;
+    const a = analyzeRun(run, scoreByKey.get(scoreKey(run)));
+    if (a) per_run.push(a);
+  }
+
+  return {
+    generated_at: new Date().toISOString(),
+    per_run,
+    by_variant: {
+      baseline: aggregate("baseline", per_run),
+      zengram:  aggregate("zengram",  per_run),
+    },
+  };
+}
+
+export function writeAnalysis(a: Analysis): string {
+  fs.mkdirSync(path.dirname(ANALYSIS_OUT), { recursive: true });
+  fs.writeFileSync(ANALYSIS_OUT, JSON.stringify(a, null, 2), "utf8");
+  return ANALYSIS_OUT;
+}
+
+export function printAnalysis(a: Analysis): void {
+  const { baseline, zengram } = a.by_variant;
+  const fmtPct = (n: number) => `${(n * 100).toFixed(1)}%`;
+  const fmtK   = (n: number) => `${(n / 1000).toFixed(1)}k`;
+
+  console.log("\n═══ Trajectory analysis ═════════════════════════════════════════\n");
+  console.log(row("Metric", "Baseline", "Zengram"));
+  console.log("─".repeat(60));
+  console.log(row("n_runs (with trajectory)", String(baseline.n_runs), String(zengram.n_runs)));
+  console.log(row("Resolved", `${baseline.n_resolved}/${baseline.n_runs}`, `${zengram.n_resolved}/${zengram.n_runs}`));
+  console.log(row("Resolution rate", fmtPct(baseline.resolution_rate), fmtPct(zengram.resolution_rate)));
+  console.log(row("Total tokens", fmtK(baseline.total_tokens), fmtK(zengram.total_tokens)));
+  console.log(row("Resolved / 1M tok ★", baseline.resolved_per_million_tokens.toFixed(2), zengram.resolved_per_million_tokens.toFixed(2)));
+  console.log(row("Median tokens / run", fmtK(baseline.median_total_tokens), fmtK(zengram.median_total_tokens)));
+  console.log(row("Median turns / run", baseline.median_turns.toFixed(1), zengram.median_turns.toFixed(1)));
+
+  console.log("\n─── Wasted-action distribution ──────────────────────────────────\n");
+  console.log(row("Tag", "Baseline", "Zengram"));
+  console.log("─".repeat(60));
+  const tags: WasteTag[] = ["useful", "redundant_read", "premature_test", "lint_only", "error_retry"];
+  for (const t of tags) {
+    const b = baseline.tag_distribution[t];
+    const z = zengram.tag_distribution[t];
+    const bs = baseline.tag_share[t] ?? 0;
+    const zs = zengram.tag_share[t] ?? 0;
+    console.log(row(t, `${b} (${fmtPct(bs)})`, `${z} (${fmtPct(zs)})`));
+  }
+
+  console.log("\n─── Run flags ───────────────────────────────────────────────────\n");
+  console.log(row("Flag", "Baseline", "Zengram"));
+  console.log("─".repeat(60));
+  for (const f of ["no_edit", "high_redundancy"] as RunFlag[]) {
+    console.log(row(f, String(baseline.run_flag_counts[f]), String(zengram.run_flag_counts[f])));
+  }
+
+  if (baseline.top_redundant_files.length > 0 || zengram.top_redundant_files.length > 0) {
+    console.log("\n─── Top redundantly-read files (zengram) ────────────────────────\n");
+    for (const f of zengram.top_redundant_files.slice(0, 5)) {
+      console.log(`  ${f.redundant_reads}× across ${f.runs} run(s)  ${trimPath(f.path)}`);
+    }
+  }
+  console.log("");
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function loadJsonDir<T>(dir: string): T[] {
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith(".json"))
+    .map((f) => JSON.parse(fs.readFileSync(path.join(dir, f), "utf8")) as T);
+}
+
+function median(arr: number[]): number {
+  if (arr.length === 0) return 0;
+  const sorted = [...arr].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1]! + sorted[mid]!) / 2 : sorted[mid]!;
+}
+
+function row(a: string, b: string, c: string): string {
+  return `${a.padEnd(28)} ${b.padEnd(14)} ${c.padEnd(14)}`;
+}
+
+function trimPath(p: string): string {
+  // Bench repo-cache paths look like /tmp/zengram-bench-repo-XXXXXX/django/...
+  // Strip the unstable prefix so the same file across runs collapses visually.
+  return p.replace(/^\/tmp\/zengram-bench-repo-[A-Za-z0-9]+\//, "");
+}

--- a/harness/src/index.ts
+++ b/harness/src/index.ts
@@ -17,6 +17,7 @@
 import { program } from "commander";
 import { runBenchmark } from "./run.js";
 import { buildReport, printReport } from "./report.js";
+import { buildAnalysis, printAnalysis, writeAnalysis } from "./analyze.js";
 import type { Variant } from "./types.js";
 
 program
@@ -119,6 +120,26 @@ program
       console.log(JSON.stringify(report, null, 2));
     } else {
       printReport(report);
+    }
+  });
+
+// ── bench analyze ─────────────────────────────────────────────────────────────
+
+program
+  .command("analyze")
+  .description("Tag tool calls with wasted-action classes and print aggregates")
+  .option("--format <fmt>", "stdout format: table (default) or json", "table")
+  .option("--no-write", "skip writing results/analysis.json")
+  .action((opts) => {
+    const a = buildAnalysis();
+    if (opts.write !== false) {
+      const out = writeAnalysis(a);
+      if (opts.format !== "json") console.log(`Wrote ${out}`);
+    }
+    if (opts.format === "json") {
+      console.log(JSON.stringify(a, null, 2));
+    } else {
+      printAnalysis(a);
     }
   });
 

--- a/harness/src/types.ts
+++ b/harness/src/types.ts
@@ -13,6 +13,31 @@ export interface SweTask {
 /** Which agent variant to run. */
 export type Variant = "baseline" | "zengram";
 
+/** One tool invocation captured from the run --format json event stream. */
+export interface ToolCallRecord {
+  turn: number;                              // step index in which the call ran (1-based)
+  tool: string;                              // "read" | "edit" | "bash" | "grep" | ...
+  input_summary: string;                     // tool-specific compact summary
+  status: "completed" | "error";
+  duration_ms: number;
+  output_chars: number;                      // size of tool output
+}
+
+/** Per-file activity within a run; useful for spotting redundant reads. */
+export interface FileTouchRecord {
+  path: string;
+  reads: number;
+  edits: number;
+}
+
+/** Per-run trajectory of tool calls, the basis for wasted-action analysis. */
+export interface Trajectory {
+  tool_counts: Record<string, number>;
+  files_touched: FileTouchRecord[];
+  bash_commands: string[];
+  records: ToolCallRecord[];
+}
+
 /** Raw output from one agent run against one task. */
 export interface RunResult {
   task_id: string;
@@ -24,9 +49,12 @@ export interface RunResult {
   turns: number;
   prompt_tokens: number;
   completion_tokens: number;
+  cache_read_tokens: number;
+  turns_with_cache_hit: number;
   duration_ms: number;
   error?: string;       // set if status !== "completed"
   session_id?: string;  // Zengram session ID (zengram variant only)
+  trajectory?: Trajectory;  // present when adapter supports --trajectory-json
 }
 
 /** Scoring result from the Python scorer. */

--- a/scripts/run-baseline.sh
+++ b/scripts/run-baseline.sh
@@ -13,7 +13,7 @@
 #   OPENCODE_BIN   path to opencode binary (default: "opencode")
 set -euo pipefail
 
-PROBLEM="" REPO="" TURNS=30 PATCH="" USAGE=""
+PROBLEM="" REPO="" TURNS=30 PATCH="" USAGE="" TRAJ=""
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -23,6 +23,7 @@ while [[ $# -gt 0 ]]; do
     --max-turns)         TURNS="$2";       shift 2 ;;
     --output-patch)      PATCH="$2";       shift 2 ;;
     --usage-json)        USAGE="$2";       shift 2 ;;
+    --trajectory-json)   TRAJ="$2";        shift 2 ;;
     *)                   shift ;;
   esac
 done
@@ -42,7 +43,10 @@ trap 'rm -f "$EVENTS_FILE"; rm -rf "$RUN_DATA_DIR"' EXIT
 # OPENCODE_CONFIG_CONTENT is merged over file-based config at startup.
 # "build" is the default primary agent.
 export OPENCODE_CONFIG_CONTENT
-OPENCODE_CONFIG_CONTENT=$(printf '{"agent":{"build":{"steps":%d}}}' "$TURNS")
+SAMPLER=""
+[[ -n "${OPENCODE_BENCH_TOP_P:-}"      ]] && SAMPLER+=$(printf ',"top_p":%s'      "$OPENCODE_BENCH_TOP_P")
+[[ -n "${OPENCODE_BENCH_TEMPERATURE:-}" ]] && SAMPLER+=$(printf ',"temperature":%s' "$OPENCODE_BENCH_TEMPERATURE")
+OPENCODE_CONFIG_CONTENT=$(printf '{"agent":{"build":{"steps":%d%s}}}' "$TURNS" "$SAMPLER")
 
 # ── Run OpenCode (baseline = SQLite, no Zengram) ─────────────────────────────
 # Pipe problem statement via stdin — avoids shell-quoting issues for large prompts.
@@ -51,9 +55,14 @@ OPENCODE_CONFIG_CONTENT=$(printf '{"agent":{"build":{"steps":%d}}}' "$TURNS")
 run_once() {
   : > "$EVENTS_FILE"
   rm -rf "$RUN_DATA_DIR" && mkdir -p "$RUN_DATA_DIR"
+  local model_args=()
+  if [[ -n "${OPENCODE_BENCH_MODEL:-}" ]]; then
+    model_args=(--model "$OPENCODE_BENCH_MODEL")
+  fi
   XDG_DATA_HOME="$RUN_DATA_DIR" OPENCODE_STORAGE=sqlite "$OPENCODE_BIN" run \
     --format json \
     --dir    "$REPO" \
+    "${model_args[@]}" \
     < "$PROBLEM" > "$EVENTS_FILE" 2>&1 || {
       echo "[adapter] opencode exited non-zero, capturing partial results" >&2
     }
@@ -91,15 +100,55 @@ fi
 # ── Capture diff ─────────────────────────────────────────────────────────────
 git -C "$REPO" diff HEAD > "$PATCH"
 
-# ── Extract token totals from step_finish events ─────────────────────────────
-# Each step_finish JSON line has: { type:"step_finish", part:{ tokens:{input,output,...} } }
-python3 - "$EVENTS_FILE" "$USAGE" <<'PY'
+# ── Extract token totals + trajectory from event stream ─────────────────────
+# step_finish: { type:"step_finish", part:{ tokens:{input,output,cache:{read}} } }
+# tool_use:    { type:"tool_use",    part:{ tool, callID, state:{ status, input,
+#                                                                output, time:{start,end} } } }
+python3 - "$EVENTS_FILE" "$USAGE" "${TRAJ:-}" <<'PY'
 import sys, json
 
-events_file, usage_file = sys.argv[1], sys.argv[2]
+events_file = sys.argv[1]
+usage_file  = sys.argv[2]
+traj_file   = sys.argv[3] if len(sys.argv) > 3 and sys.argv[3] else None
+
 turns = 0
 prompt_tok = 0
 completion_tok = 0
+cache_read_tok = 0
+turns_with_cache_hit = 0
+
+current_turn = 0          # incremented on each step_start; tool_use rows tag the in-flight turn
+tool_counts = {}
+records = []
+files = {}                # path -> {"reads": n, "edits": n}
+bash_commands = []
+
+def file_stat(path):
+    if path not in files:
+        files[path] = {"reads": 0, "edits": 0}
+    return files[path]
+
+def summarize(tool, inp):
+    if not isinstance(inp, dict):
+        return ""
+    fp = inp.get("filePath") or inp.get("path")
+    if tool in ("read", "edit", "write") and fp:
+        return f"path={fp}"
+    if tool == "bash":
+        cmd = (inp.get("command") or "")[:80]
+        return f"cmd={cmd}"
+    if tool == "grep":
+        pat = inp.get("pattern") or ""
+        where = inp.get("path") or inp.get("include") or ""
+        return f"pattern={pat} path={where}".strip()
+    if tool == "glob":
+        return f"pattern={inp.get('pattern') or ''}"
+    if tool == "codesearch":
+        return f"q={inp.get('query') or inp.get('q') or ''}"
+    if tool == "webfetch":
+        return f"url={inp.get('url') or ''}"
+    keys = ",".join(sorted(k for k in inp.keys() if not k.startswith('_')))[:80]
+    return f"keys={keys}"
 
 with open(events_file, "r", errors="replace") as f:
     for line in f:
@@ -110,12 +159,66 @@ with open(events_file, "r", errors="replace") as f:
             evt = json.loads(line)
         except Exception:
             continue
-        if evt.get("type") == "step_finish":
+        et = evt.get("type")
+        if et == "step_start":
+            current_turn += 1
+        elif et == "step_finish":
             turns += 1
             tok = (evt.get("part") or {}).get("tokens") or {}
             prompt_tok     += tok.get("input",  0)
             completion_tok += tok.get("output", 0)
+            cache = (tok.get("cache") or {})
+            cr = cache.get("read", 0)
+            cache_read_tok += cr
+            if cr > 0:
+                turns_with_cache_hit += 1
+        elif et == "tool_use":
+            part = evt.get("part") or {}
+            tool = part.get("tool") or "unknown"
+            state = part.get("state") or {}
+            status = state.get("status") or "unknown"
+            inp = state.get("input") or {}
+            t = state.get("time") or {}
+            dur = int((t.get("end") or 0) - (t.get("start") or 0)) if t.get("end") and t.get("start") else 0
+            out = state.get("output") or ""
+            tool_counts[tool] = tool_counts.get(tool, 0) + 1
+            records.append({
+                "turn": max(current_turn, 1),
+                "tool": tool,
+                "input_summary": summarize(tool, inp),
+                "status": status if status in ("completed", "error") else "completed",
+                "duration_ms": dur,
+                "output_chars": len(out) if isinstance(out, str) else 0,
+            })
+            fp = inp.get("filePath") or inp.get("path") if isinstance(inp, dict) else None
+            if tool == "read" and fp:
+                file_stat(fp)["reads"] += 1
+            elif tool in ("edit", "write") and fp:
+                file_stat(fp)["edits"] += 1
+            elif tool == "bash" and isinstance(inp, dict):
+                cmd = (inp.get("command") or "")[:80]
+                if cmd:
+                    bash_commands.append(cmd)
 
 with open(usage_file, "w") as f:
-    json.dump({"turns": turns, "prompt_tokens": prompt_tok, "completion_tokens": completion_tok}, f)
+    json.dump({
+        "turns": turns,
+        "prompt_tokens": prompt_tok,
+        "completion_tokens": completion_tok,
+        "cache_read_tokens": cache_read_tok,
+        "turns_with_cache_hit": turns_with_cache_hit,
+    }, f)
+
+if traj_file:
+    files_touched = sorted(
+        ({"path": p, **stats} for p, stats in files.items()),
+        key=lambda r: -(r["reads"] + r["edits"]),
+    )
+    with open(traj_file, "w") as f:
+        json.dump({
+            "tool_counts": tool_counts,
+            "files_touched": files_touched,
+            "bash_commands": bash_commands,
+            "records": records,
+        }, f)
 PY

--- a/scripts/run-baseline.sh
+++ b/scripts/run-baseline.sh
@@ -41,11 +41,27 @@ trap 'rm -f "$EVENTS_FILE"; rm -rf "$RUN_DATA_DIR"' EXIT
 
 # ── Inject max-steps into agent config via env var ───────────────────────────
 # OPENCODE_CONFIG_CONTENT is merged over file-based config at startup.
-# "build" is the default primary agent.
+# "build" is the default primary agent. Sampler env vars are validated
+# against a numeric regex before being concatenated into JSON — a
+# non-numeric value (e.g. "abc" or stray quotes) would otherwise produce
+# invalid JSON and break opencode's startup in a hard-to-diagnose way.
 export OPENCODE_CONFIG_CONTENT
+NUM_RE='^[0-9]+(\.[0-9]+)?$'
+require_numeric() {
+  local name="$1" val="$2"
+  if ! [[ "$val" =~ $NUM_RE ]]; then
+    echo "ERROR: $name must be numeric (got: '$val')" >&2; exit 1
+  fi
+}
 SAMPLER=""
-[[ -n "${OPENCODE_BENCH_TOP_P:-}"      ]] && SAMPLER+=$(printf ',"top_p":%s'      "$OPENCODE_BENCH_TOP_P")
-[[ -n "${OPENCODE_BENCH_TEMPERATURE:-}" ]] && SAMPLER+=$(printf ',"temperature":%s' "$OPENCODE_BENCH_TEMPERATURE")
+if [[ -n "${OPENCODE_BENCH_TOP_P:-}" ]]; then
+  require_numeric OPENCODE_BENCH_TOP_P "$OPENCODE_BENCH_TOP_P"
+  SAMPLER+=$(printf ',"top_p":%s' "$OPENCODE_BENCH_TOP_P")
+fi
+if [[ -n "${OPENCODE_BENCH_TEMPERATURE:-}" ]]; then
+  require_numeric OPENCODE_BENCH_TEMPERATURE "$OPENCODE_BENCH_TEMPERATURE"
+  SAMPLER+=$(printf ',"temperature":%s' "$OPENCODE_BENCH_TEMPERATURE")
+fi
 OPENCODE_CONFIG_CONTENT=$(printf '{"agent":{"build":{"steps":%d%s}}}' "$TURNS" "$SAMPLER")
 
 # ── Run OpenCode (baseline = SQLite, no Zengram) ─────────────────────────────
@@ -190,15 +206,16 @@ with open(events_file, "r", errors="replace") as f:
                 "duration_ms": dur,
                 "output_chars": len(out) if isinstance(out, str) else 0,
             })
-            fp = inp.get("filePath") or inp.get("path") if isinstance(inp, dict) else None
-            if tool == "read" and fp:
-                file_stat(fp)["reads"] += 1
-            elif tool in ("edit", "write") and fp:
-                file_stat(fp)["edits"] += 1
-            elif tool == "bash" and isinstance(inp, dict):
-                cmd = (inp.get("command") or "")[:80]
-                if cmd:
-                    bash_commands.append(cmd)
+            if isinstance(inp, dict):
+                fp = inp.get("filePath") or inp.get("path")
+                if tool == "read" and fp:
+                    file_stat(fp)["reads"] += 1
+                elif tool in ("edit", "write") and fp:
+                    file_stat(fp)["edits"] += 1
+                elif tool == "bash":
+                    cmd = (inp.get("command") or "")[:80]
+                    if cmd:
+                        bash_commands.append(cmd)
 
 with open(usage_file, "w") as f:
     json.dump({

--- a/scripts/run-zengram.sh
+++ b/scripts/run-zengram.sh
@@ -17,7 +17,7 @@
 #                          Validated to be executable; error on mismatch.
 set -euo pipefail
 
-PROBLEM="" REPO="" TURNS=30 PATCH="" USAGE=""
+PROBLEM="" REPO="" TURNS=30 PATCH="" USAGE="" TRAJ=""
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -27,6 +27,7 @@ while [[ $# -gt 0 ]]; do
     --max-turns)         TURNS="$2";       shift 2 ;;
     --output-patch)      PATCH="$2";       shift 2 ;;
     --usage-json)        USAGE="$2";       shift 2 ;;
+    --trajectory-json)   TRAJ="$2";        shift 2 ;;
     *)                   shift ;;
   esac
 done
@@ -74,7 +75,12 @@ fi
 
 # ── Inject max-steps into agent config via env var ───────────────────────────
 export OPENCODE_CONFIG_CONTENT
-OPENCODE_CONFIG_CONTENT=$(printf '{"agent":{"build":{"steps":%d}}}' "$TURNS")
+# Optional sampler overrides (e.g. for local llama.cpp where opencode's default
+# top_p=1 hangs on small Qwen models). Falls back to opencode defaults if unset.
+SAMPLER=""
+[[ -n "${OPENCODE_BENCH_TOP_P:-}"      ]] && SAMPLER+=$(printf ',"top_p":%s'      "$OPENCODE_BENCH_TOP_P")
+[[ -n "${OPENCODE_BENCH_TEMPERATURE:-}" ]] && SAMPLER+=$(printf ',"temperature":%s' "$OPENCODE_BENCH_TEMPERATURE")
+OPENCODE_CONFIG_CONTENT=$(printf '{"agent":{"build":{"steps":%d%s}}}' "$TURNS" "$SAMPLER")
 
 # ── Run OpenCode fork (Zengram storage enabled by default) ───────────────────
 # The fork writes every turn to Zengram as events arrive.  We also capture the
@@ -88,9 +94,14 @@ run_once() {
   if [[ -z "${OPENCODE_PINNED_DATA_DIR:-}" ]]; then
     rm -rf "$RUN_DATA_DIR" && mkdir -p "$RUN_DATA_DIR"
   fi
+  local model_args=()
+  if [[ -n "${OPENCODE_BENCH_MODEL:-}" ]]; then
+    model_args=(--model "$OPENCODE_BENCH_MODEL")
+  fi
   XDG_DATA_HOME="$RUN_DATA_DIR" "$OPENCODE_ZENGRAM_BIN" run \
     --format json \
     --dir    "$REPO" \
+    "${model_args[@]}" \
     < "$PROBLEM" > "$EVENTS_FILE" 2>&1 || {
       echo "[adapter] opencode-zengram exited non-zero, capturing partial results" >&2
     }
@@ -128,17 +139,56 @@ fi
 # ── Capture diff ─────────────────────────────────────────────────────────────
 git -C "$REPO" diff HEAD > "$PATCH"
 
-# ── Extract token totals from step_finish events ─────────────────────────────
-# step_finish events carry: { type:"step_finish", sessionID, part:{ tokens:{input,output,...} } }
+# ── Extract token totals + trajectory from event stream ─────────────────────
+# step_finish: tokens (input/output/cache.read) and turn count
+# tool_use:    per-call records (tool, input summary, status, duration, output size)
 # We also surface the Zengram session ID for downstream tracing.
-python3 - "$EVENTS_FILE" "$USAGE" <<'PY'
+python3 - "$EVENTS_FILE" "$USAGE" "${TRAJ:-}" <<'PY'
 import sys, json
 
-events_file, usage_file = sys.argv[1], sys.argv[2]
+events_file = sys.argv[1]
+usage_file  = sys.argv[2]
+traj_file   = sys.argv[3] if len(sys.argv) > 3 and sys.argv[3] else None
+
 turns = 0
 prompt_tok = 0
 completion_tok = 0
+cache_read_tok = 0
+turns_with_cache_hit = 0
 session_id = None
+
+current_turn = 0
+tool_counts = {}
+records = []
+files = {}
+bash_commands = []
+
+def file_stat(path):
+    if path not in files:
+        files[path] = {"reads": 0, "edits": 0}
+    return files[path]
+
+def summarize(tool, inp):
+    if not isinstance(inp, dict):
+        return ""
+    fp = inp.get("filePath") or inp.get("path")
+    if tool in ("read", "edit", "write") and fp:
+        return f"path={fp}"
+    if tool == "bash":
+        cmd = (inp.get("command") or "")[:80]
+        return f"cmd={cmd}"
+    if tool == "grep":
+        pat = inp.get("pattern") or ""
+        where = inp.get("path") or inp.get("include") or ""
+        return f"pattern={pat} path={where}".strip()
+    if tool == "glob":
+        return f"pattern={inp.get('pattern') or ''}"
+    if tool == "codesearch":
+        return f"q={inp.get('query') or inp.get('q') or ''}"
+    if tool == "webfetch":
+        return f"url={inp.get('url') or ''}"
+    keys = ",".join(sorted(k for k in inp.keys() if not k.startswith('_')))[:80]
+    return f"keys={keys}"
 
 with open(events_file, "r", errors="replace") as f:
     for line in f:
@@ -151,15 +201,69 @@ with open(events_file, "r", errors="replace") as f:
             continue
         if evt.get("sessionID") and not session_id:
             session_id = evt["sessionID"]
-        if evt.get("type") == "step_finish":
+        et = evt.get("type")
+        if et == "step_start":
+            current_turn += 1
+        elif et == "step_finish":
             turns += 1
             tok = (evt.get("part") or {}).get("tokens") or {}
             prompt_tok     += tok.get("input",  0)
             completion_tok += tok.get("output", 0)
+            cache = (tok.get("cache") or {})
+            cr = cache.get("read", 0)
+            cache_read_tok += cr
+            if cr > 0:
+                turns_with_cache_hit += 1
+        elif et == "tool_use":
+            part = evt.get("part") or {}
+            tool = part.get("tool") or "unknown"
+            state = part.get("state") or {}
+            status = state.get("status") or "unknown"
+            inp = state.get("input") or {}
+            t = state.get("time") or {}
+            dur = int((t.get("end") or 0) - (t.get("start") or 0)) if t.get("end") and t.get("start") else 0
+            out = state.get("output") or ""
+            tool_counts[tool] = tool_counts.get(tool, 0) + 1
+            records.append({
+                "turn": max(current_turn, 1),
+                "tool": tool,
+                "input_summary": summarize(tool, inp),
+                "status": status if status in ("completed", "error") else "completed",
+                "duration_ms": dur,
+                "output_chars": len(out) if isinstance(out, str) else 0,
+            })
+            fp = inp.get("filePath") or inp.get("path") if isinstance(inp, dict) else None
+            if tool == "read" and fp:
+                file_stat(fp)["reads"] += 1
+            elif tool in ("edit", "write") and fp:
+                file_stat(fp)["edits"] += 1
+            elif tool == "bash" and isinstance(inp, dict):
+                cmd = (inp.get("command") or "")[:80]
+                if cmd:
+                    bash_commands.append(cmd)
 
-out = {"turns": turns, "prompt_tokens": prompt_tok, "completion_tokens": completion_tok}
+out = {
+    "turns": turns,
+    "prompt_tokens": prompt_tok,
+    "completion_tokens": completion_tok,
+    "cache_read_tokens": cache_read_tok,
+    "turns_with_cache_hit": turns_with_cache_hit,
+}
 if session_id:
     out["session_id"] = session_id
 with open(usage_file, "w") as f:
     json.dump(out, f)
+
+if traj_file:
+    files_touched = sorted(
+        ({"path": p, **stats} for p, stats in files.items()),
+        key=lambda r: -(r["reads"] + r["edits"]),
+    )
+    with open(traj_file, "w") as f:
+        json.dump({
+            "tool_counts": tool_counts,
+            "files_touched": files_touched,
+            "bash_commands": bash_commands,
+            "records": records,
+        }, f)
 PY

--- a/scripts/run-zengram.sh
+++ b/scripts/run-zengram.sh
@@ -77,9 +77,25 @@ fi
 export OPENCODE_CONFIG_CONTENT
 # Optional sampler overrides (e.g. for local llama.cpp where opencode's default
 # top_p=1 hangs on small Qwen models). Falls back to opencode defaults if unset.
+# Values are validated against a numeric regex before concatenation — a
+# non-numeric value would otherwise produce invalid JSON and break opencode
+# startup in a hard-to-diagnose way.
+NUM_RE='^[0-9]+(\.[0-9]+)?$'
+require_numeric() {
+  local name="$1" val="$2"
+  if ! [[ "$val" =~ $NUM_RE ]]; then
+    echo "ERROR: $name must be numeric (got: '$val')" >&2; exit 1
+  fi
+}
 SAMPLER=""
-[[ -n "${OPENCODE_BENCH_TOP_P:-}"      ]] && SAMPLER+=$(printf ',"top_p":%s'      "$OPENCODE_BENCH_TOP_P")
-[[ -n "${OPENCODE_BENCH_TEMPERATURE:-}" ]] && SAMPLER+=$(printf ',"temperature":%s' "$OPENCODE_BENCH_TEMPERATURE")
+if [[ -n "${OPENCODE_BENCH_TOP_P:-}" ]]; then
+  require_numeric OPENCODE_BENCH_TOP_P "$OPENCODE_BENCH_TOP_P"
+  SAMPLER+=$(printf ',"top_p":%s' "$OPENCODE_BENCH_TOP_P")
+fi
+if [[ -n "${OPENCODE_BENCH_TEMPERATURE:-}" ]]; then
+  require_numeric OPENCODE_BENCH_TEMPERATURE "$OPENCODE_BENCH_TEMPERATURE"
+  SAMPLER+=$(printf ',"temperature":%s' "$OPENCODE_BENCH_TEMPERATURE")
+fi
 OPENCODE_CONFIG_CONTENT=$(printf '{"agent":{"build":{"steps":%d%s}}}' "$TURNS" "$SAMPLER")
 
 # ── Run OpenCode fork (Zengram storage enabled by default) ───────────────────
@@ -232,15 +248,16 @@ with open(events_file, "r", errors="replace") as f:
                 "duration_ms": dur,
                 "output_chars": len(out) if isinstance(out, str) else 0,
             })
-            fp = inp.get("filePath") or inp.get("path") if isinstance(inp, dict) else None
-            if tool == "read" and fp:
-                file_stat(fp)["reads"] += 1
-            elif tool in ("edit", "write") and fp:
-                file_stat(fp)["edits"] += 1
-            elif tool == "bash" and isinstance(inp, dict):
-                cmd = (inp.get("command") or "")[:80]
-                if cmd:
-                    bash_commands.append(cmd)
+            if isinstance(inp, dict):
+                fp = inp.get("filePath") or inp.get("path")
+                if tool == "read" and fp:
+                    file_stat(fp)["reads"] += 1
+                elif tool in ("edit", "write") and fp:
+                    file_stat(fp)["edits"] += 1
+                elif tool == "bash":
+                    cmd = (inp.get("command") or "")[:80]
+                    if cmd:
+                        bash_commands.append(cmd)
 
 out = {
     "turns": turns,


### PR DESCRIPTION
## Summary

- Adapters (`scripts/run-{baseline,zengram}.sh`) now extract a per-run **trajectory** (tool calls, files touched, bash commands, per-call records with turn/duration/output size) from the JSONL event stream that opencode already emits, alongside existing token totals. New optional `--trajectory-json` adapter flag.
- Harness folds the trajectory into `RunResult` JSON. New types (`Trajectory`, `ToolCallRecord`, `FileTouchRecord`) on `harness/src/types.ts`. Field is optional, so pre-instrumentation runs still parse.
- New `bench analyze` subcommand (`harness/src/analyze.ts`) classifies each tool call into a wasted-action bucket — `redundant_read`, `premature_test`, `lint_only`, `error_retry` — plus per-run flags (`no_edit`, `high_redundancy`). Aggregates across runs, surfaces the **north-star metric** `resolved_per_million_tokens`, and writes `results/analysis.json` with a summary table to stdout.

## Why

The 2026-04 bench showed Zengram burning 1.85× tokens vs the SQLite baseline with no quality gain. Without per-call instrumentation we can't tell which waste class dominates — `redundant_read` from per-turn re-injection? `no_edit` from ambient browsing? Premature tests? This change is the measurement substrate to find out.

The framing this PR materializes: optimize the agent loop like a compiler, not a chat app. The metric `resolved / total_tokens` (not raw `resolved %`) is what we steer on; the per-call tags tell us which loop pattern to attack first.

## Scope (what's NOT here)

This PR is bench-only. The eventual home for these layers is staged:

| Layer | Where it landed | Eventual home |
|---|---|---|
| JSONL→trajectory parser (python in adapters) | `scripts/run-*.sh` | **opencode** — first-class `run --trajectory-json` flag (DRY, lets parser see internal data we currently drop, e.g. read line-ranges → fixes chunked-read conflation in `redundant_read`) |
| Per-call waste classifier | `harness/src/analyze.ts` | **opencode runtime** then **zengram** — measuring waste post-hoc is bench-only value; the win is preventing it (runtime nudges) and remembering it across sessions (zengram plays tagged with waste classes) |
| Cross-variant aggregator + `resolved/1M tok` metric | `harness/src/analyze.ts` | **stays in bench** — pure "did the change help?" |

Follow-up issues for the migrations would be useful — leaving them open intentionally rather than rushing to move the parser before we have bench data confirming which waste classes correlate with token burn.

## Caveats baked into the heuristics

- `redundant_read` conflates chunked re-reads of the same file with literal re-reads (trajectory only carries paths, not offsets). This is fixable once the parser moves into opencode where line-ranges are available.
- `premature_test` matches a hardcoded list of test runners (`pytest`, `manage.py test`, `bun test`, `jest`, `vitest`, `go test`). Tune against bench data.
- Pre-instrumentation runs (no `trajectory` field) are silently skipped by the analyzer. The 2026-04-29 baseline data falls into this bucket.

## Test plan

- [ ] `bunx tsc --noEmit` in `harness/` — passes
- [ ] Smoke run: 1 task × 2 variants × 1 rep against local model — adapter writes `trajectory.json`, harness folds it into `RunResult`, `bench analyze` produces a populated table for the variant that completed
- [ ] Empty-trajectory case (run with zero events) — analyzer returns `{tool_counts: {}, files_touched: [], records: []}` cleanly, no crash
- [ ] Pre-instrumentation runs silently skipped by `bench analyze`
- [ ] Full N-task pass + `bench score` + `bench analyze` to populate the north-star metric and validate per-task aggregates (left as follow-up before merging if reviewers want signal beyond the smoke run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)