### PR TITLE
feat(analyze): chunked-aware redundant_read detection

### DIFF
--- a/harness/src/analyze.ts
+++ b/harness/src/analyze.ts
@@ -33,7 +33,7 @@ const ANALYSIS_OUT = path.join(ROOT, "results", "analysis.json");
 /** Per-call waste tag. "useful" is the catch-all for non-flagged calls. */
 export type WasteTag =
   | "useful"
-  | "redundant_read"   // same file read 2+ times in this run (chunked reads conflated, see note)
+  | "redundant_read"   // literal re-read of same file+offset+limit (chunked re-reads of different ranges are NOT flagged when records carry `input`)
   | "premature_test"   // bash test runner ran before any edit/write landed
   | "lint_only"        // bash matched a formatter/linter, not a test
   | "error_retry";     // this call retried a same-tool same-input call that errored
@@ -110,8 +110,40 @@ const LINT_PATTERNS = [
 
 // ── Per-run classification ───────────────────────────────────────────────────
 
+/**
+ * Build the dedup key used by `redundant_read` and `error_retry` detection.
+ *
+ * When `input` is present (opencode#22+ trajectories), key on `path|offset|limit`
+ * for reads — distinguishes chunked re-reads of different ranges of the same
+ * file from literal re-reads of the same lines. Both are common in agent
+ * sessions and only the latter is genuine waste.
+ *
+ * Falls back to `input_summary` for older bench-produced trajectories that
+ * don't carry the structured `input` field.
+ */
+function readDedupKey(r: ToolCallRecord): string {
+  if (!r.input) return r.input_summary;
+  const fp = typeof r.input.filePath === "string"
+    ? r.input.filePath
+    : typeof r.input.path === "string"
+      ? r.input.path
+      : "";
+  if (!fp) return r.input_summary;
+  // offset/limit may be number, undefined, or null — coerce to a stable string
+  // so the key matches across "absent" and "explicitly default" forms.
+  const off = typeof r.input.offset === "number" ? String(r.input.offset) : "";
+  const lim = typeof r.input.limit === "number" ? String(r.input.limit) : "";
+  return `path=${fp}|off=${off}|lim=${lim}`;
+}
+
+function retryDedupKey(r: ToolCallRecord): string {
+  // For non-read tools fall back to input_summary; same-tool same-input is the
+  // signal we want for error_retry across all tools.
+  return r.tool === "read" ? readDedupKey(r) : r.input_summary;
+}
+
 function classifyRecords(records: ToolCallRecord[]): TaggedRecord[] {
-  const seenReadPaths = new Set<string>();
+  const seenReadKeys = new Set<string>();
   let firstEditIdx = records.findIndex(
     (r) => (r.tool === "edit" || r.tool === "write") && r.status === "completed",
   );
@@ -123,11 +155,9 @@ function classifyRecords(records: ToolCallRecord[]): TaggedRecord[] {
     let tag: WasteTag = "useful";
 
     if (r.tool === "read") {
-      // input_summary is `path=<file>`; group by exact summary so we don't
-      // need to re-parse. Chunked reads of the same file (different offsets)
-      // get conflated — flagged in the type doc above.
-      if (seenReadPaths.has(r.input_summary)) tag = "redundant_read";
-      else seenReadPaths.add(r.input_summary);
+      const key = readDedupKey(r);
+      if (seenReadKeys.has(key)) tag = "redundant_read";
+      else seenReadKeys.add(key);
     } else if (r.tool === "bash") {
       const cmd = r.input_summary.startsWith("cmd=") ? r.input_summary.slice(4) : r.input_summary;
       if (LINT_PATTERNS.some((p) => p.test(cmd))) tag = "lint_only";
@@ -135,10 +165,10 @@ function classifyRecords(records: ToolCallRecord[]): TaggedRecord[] {
     }
 
     // error_retry overrides the above: if the *previous* record errored on
-    // the same tool with same input_summary, this record is a retry.
+    // the same tool with the same input, this record is a retry.
     if (i > 0) {
       const prev = records[i - 1]!;
-      if (prev.status === "error" && prev.tool === r.tool && prev.input_summary === r.input_summary) {
+      if (prev.status === "error" && prev.tool === r.tool && retryDedupKey(prev) === retryDedupKey(r)) {
         tag = "error_retry";
       }
     }

--- a/harness/src/analyze.ts
+++ b/harness/src/analyze.ts
@@ -157,7 +157,11 @@ function classifyRecords(records: ToolCallRecord[]): TaggedRecord[] {
     if (r.tool === "read") {
       const key = readDedupKey(r);
       if (seenReadKeys.has(key)) tag = "redundant_read";
-      else seenReadKeys.add(key);
+      // Only successful reads count as "seen". An errored read produced no
+      // output, so a later successful read of the same range isn't waste —
+      // it's the agent recovering. error_retry still catches the immediate-
+      // next-record retry case for both reads and other tools.
+      if (r.status === "completed") seenReadKeys.add(key);
     } else if (r.tool === "bash") {
       const cmd = r.input_summary.startsWith("cmd=") ? r.input_summary.slice(4) : r.input_summary;
       if (LINT_PATTERNS.some((p) => p.test(cmd))) tag = "lint_only";

--- a/harness/src/types.ts
+++ b/harness/src/types.ts
@@ -21,6 +21,13 @@ export interface ToolCallRecord {
   status: "completed" | "error";
   duration_ms: number;
   output_chars: number;                      // size of tool output
+  /**
+   * Raw structured tool input. Present on trajectories produced by opencode's
+   * native --trajectory-json (since opencode#22). Older bench-produced
+   * trajectories don't carry this field; consumers should treat it as
+   * optional and fall back to `input_summary` when absent.
+   */
+  input?: Record<string, unknown>;
 }
 
 /** Per-file activity within a run; useful for spotting redundant reads. */


### PR DESCRIPTION
## Summary

opencode#22 (now merged) and zengram-bench#8 (the adapter passthrough, also merged) produce trajectories where each per-call record carries the raw structured tool input. This PR uses that to distinguish **chunked re-reads of different ranges** of the same file from **literal re-reads of the same lines** — both were lumped under `redundant_read` before, but only the latter is genuine waste.

## Why this matters

The 2026-05-03 survey25 reported `redundant_read` at 17–20% of all tool calls — but that count was inflated because the bench parser only saw `input_summary = "path=foo.py"` for every read regardless of offset. A session that reads a 2000-line file in three 800-line chunks looked like two redundant reads when it was actually a normal chunked read pattern.

That made it impossible to tell whether the **dj-16595 3.5× blowup** (zengram = 274k tokens vs baseline = 78k) was driven by genuine waste or by a model that legitimately needed to inspect a long file. With chunk-aware detection the next bench cycle gives an honest signal we can tune `ZENGRAM_PLAY_MAX_DISTANCE` against.

## What changed

**`types.ts`** — add `input?: Record<string, unknown>` to `ToolCallRecord`. Optional for backward compatibility: trajectories produced before opencode#22 / bench#8 don't carry it.

**`analyze.ts`** — extract `readDedupKey(r)` that keys reads on `path|offset|limit` when `input` is present, falling back to `input_summary` when it isn't. `classifyRecords` uses it for read redundancy detection; `error_retry` uses the same key (via `retryDedupKey`) so a read retry is detected by structured input rather than the flattened summary.

## Smoke verification

Re-running `bench analyze` on the existing survey25 trajectories (which lack `input`) produces **identical numbers** to before — confirming the fallback is wired correctly.

A focused inline test of the dedup logic covers all four shapes:

| case | input shape | expected | got |
|---|---|---|---|
| legacy (no `input`) — same path twice | absent | redundant | ✓ redundant |
| new — same path AND same `offset`/`limit` | `{filePath, offset:0, limit:100}` × 2 | redundant | ✓ redundant |
| new — same path, **different offsets** | `{offset:0}`, `{offset:100}`, `{offset:200}` | none | ✓ all useful |
| new — whole-file, chunk, whole-file again | `{}`, `{offset:0,limit:100}`, `{}` | 3rd is redundant vs 1st | ✓ 3rd flagged |

## Test plan

- [x] `bunx tsc --noEmit` — passes
- [x] `bench analyze` on existing survey25 results — same `redundant_read` counts (62 baseline / 50 zengram), same per-task output (legacy fallback path)
- [x] Inline dedup test covering legacy / same-chunk / chunked / mixed cases — all pass

## Out of scope

- Re-running survey25 with the new analyzer to get **honest** `redundant_read` counts — that's the next bench cycle, separate.
- Acting on the new signal (tightening `ZENGRAM_PLAY_MAX_DISTANCE` based on cleaner data) — separate investigation once we have a fresh corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)