### PR TITLE
fix(scorer): patch-hash invalidation — detect stale scores from prior bench rounds

### DIFF
--- a/harness/scorer/score.py
+++ b/harness/scorer/score.py
@@ -124,20 +124,38 @@ def run_tests(repo_dir: Path, test_ids: list[str]) -> tuple[list[str], list[str]
     return passed, failed
 
 
-def score_run(run: dict, task: dict, scores_dir: Path) -> dict:
+def score_run(run: dict, task: dict, scores_dir: Path, force: bool = False) -> dict:
     task_id = run["task_id"]
     variant = run["variant"]
     run_idx = run["run_index"]
     patch   = run.get("patch", "")
+    # Hash the patch so we can detect when an existing score file was
+    # generated from a different patch (e.g. a prior bench round wrote the
+    # score, current round produced a different patch but shared task-id).
+    # Skipping by file existence alone caused rounds 2+ to silently reuse
+    # round 1's scores; the "low success rate" reported in the round 1-5
+    # elevation-plan analysis was largely this caching artifact.
+    import hashlib
+    patch_hash = hashlib.sha256(patch.encode("utf-8")).hexdigest()[:16]
 
     out_path = scores_dir / f"{task_id}_{variant}_{run_idx}.json"
-    if out_path.exists():
-        print(f"  skip {task_id} {variant} #{run_idx} (score exists)")
-        return json.loads(out_path.read_text())
+    if out_path.exists() and not force:
+        try:
+            cached = json.loads(out_path.read_text())
+        except Exception:
+            cached = {}
+        if cached.get("patch_hash") == patch_hash:
+            print(f"  skip {task_id} {variant} #{run_idx} (score current for this patch)")
+            return cached
+        # Score exists but was written for a different patch — treat as stale.
+        print(f"  rescoring {task_id} {variant} #{run_idx} (cached for old patch)")
 
     print(f"  scoring {task_id} {variant} #{run_idx} …", end=" ", flush=True)
 
     def write(result: dict) -> dict:
+        # Persist the patch hash so a future invocation can detect staleness
+        # without re-running the test suite.
+        result["patch_hash"] = patch_hash
         out_path.write_text(json.dumps(result, indent=2))
         return result
 
@@ -272,6 +290,8 @@ def main():
     parser.add_argument("--scores-dir",  default=str(SCORES_DIR))
     parser.add_argument("--tasks-cache", default=str(TASKS_CACHE))
     parser.add_argument("--task-id",     help="Score only this task ID")
+    parser.add_argument("--force", action="store_true",
+                        help="Re-score even when score file exists with matching patch hash")
     args = parser.parse_args()
 
     runs_dir   = Path(args.runs_dir)
@@ -295,7 +315,7 @@ def main():
         if task_id not in tasks:
             print(f"  WARNING: task {task_id} not in cache, skipping")
             continue
-        score_run(run, tasks[task_id], scores_dir)
+        score_run(run, tasks[task_id], scores_dir, force=args.force)
 
     # Quick summary.
     score_files = list(scores_dir.glob("*.json"))

--- a/harness/scorer/score.py
+++ b/harness/scorer/score.py
@@ -140,15 +140,25 @@ def score_run(run: dict, task: dict, scores_dir: Path, force: bool = False) -> d
 
     out_path = scores_dir / f"{task_id}_{variant}_{run_idx}.json"
     if out_path.exists() and not force:
+        # Distinguish three states so operators can diagnose:
+        #   1. corrupt / unreadable JSON → re-score, log the parse error
+        #   2. valid JSON but patch_hash mismatches → re-score (true staleness)
+        #   3. valid JSON with matching patch_hash → skip (cache hit)
         try:
             cached = json.loads(out_path.read_text())
-        except Exception:
+            cache_invalid = False
+            cache_error = None
+        except Exception as e:
             cached = {}
-        if cached.get("patch_hash") == patch_hash:
+            cache_invalid = True
+            cache_error = e
+        if cache_invalid:
+            print(f"  rescoring {task_id} {variant} #{run_idx} (cache file unreadable: {cache_error})")
+        elif cached.get("patch_hash") == patch_hash:
             print(f"  skip {task_id} {variant} #{run_idx} (score current for this patch)")
             return cached
-        # Score exists but was written for a different patch — treat as stale.
-        print(f"  rescoring {task_id} {variant} #{run_idx} (cached for old patch)")
+        else:
+            print(f"  rescoring {task_id} {variant} #{run_idx} (cached for old patch)")
 
     print(f"  scoring {task_id} {variant} #{run_idx} …", end=" ", flush=True)
 


### PR DESCRIPTION
## Summary

- The scorer skipped any run with an existing score file, regardless of whether the cached score reflected the current patch. Across multi-round bench cycles (survey25 round1-5), rounds share task names, so each \`score.py\` invocation only scored runs without an existing score file. Score files written by round 1 stayed in place even when round 2-5 produced different patches.
- Effect: the elevation-plan headline (1/25 BL, 3/25 ZG resolved, 2.69× res/Mtok ratio) was largely round 1's scoring re-aggregated against round-N's run metadata. Forced re-scoring of each round's archive into isolated scores dirs revealed real resolution counts of 2-3 BL, 2-5 ZG per round and a real ratio of ~1.43×.

## Fix

- Persist \`SHA-256(patch)[:16]\` in each score file.
- On subsequent invocations, treat a score as current only if its cached \`patch_hash\` matches the current run's patch. Old score files lacking the field are treated as stale and re-scored.
- Add \`--force\` for explicit re-score regardless of hash match.

## Test plan

- [x] Manual: scoring a fresh run writes \`patch_hash\` field
- [x] Manual: same patch → \"skip ... (score current for this patch)\"
- [x] Manual: clearing \`patch_hash\` from a score file → re-scores on next invocation
- [x] Manual: \`--force\` re-scores even when hash matches
- [ ] Cross-round bench cycle: verify analyzer aggregates fresh results in next survey

## Impact

This is a correctness fix for the bench measurement substrate. Every prior multi-round bench analysis is suspect; the elevation plan needs corrected numbers (separate doc PR in opencode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)