### PR TITLE
fix(harness): mark zero-turn runs as failed instead of completed

### DIFF
--- a/harness/src/agent.ts
+++ b/harness/src/agent.ts
@@ -132,12 +132,18 @@ Rules:
       ? (JSON.parse(fs.readFileSync(trajFile, "utf8")) as Trajectory)
       : undefined;
 
+    // A run that produced zero step_finish events is not "completed" no matter
+    // how cleanly the subprocess exited. The zengram adapter swallows
+    // opencode-fork's non-zero exit so the parent always sees status 0; without
+    // this gate, a wedged backend produces 0-turn 0-token results stamped
+    // "completed" — survey50_round7 (2026-05-06) lost 14 zengram runs this way.
+    const noSteps = usage.turns === 0;
     return {
       task_id:              task.task_id,
       variant,
       run_index:            runIndex,
       timestamp,
-      status:               "completed",
+      status:               noSteps ? "failed" : "completed",
       patch,
       turns:                usage.turns,
       prompt_tokens:        usage.prompt_tokens,
@@ -145,6 +151,7 @@ Rules:
       cache_read_tokens:    usage.cache_read_tokens ?? 0,
       turns_with_cache_hit: usage.turns_with_cache_hit ?? 0,
       duration_ms,
+      ...(noSteps ? { error: "agent produced no step_finish events (zero turns) — backend wedged or rate-limited past retry" } : {}),
       ...(usage.session_id ? { session_id: usage.session_id } : {}),
       ...(trajectory ? { trajectory } : {}),
     };


### PR DESCRIPTION
## Summary

- Treat `usage.turns === 0` as a failure even when the agent subprocess exits cleanly. The zengram adapter swallows `opencode-fork`'s non-zero exit so the parent never sees the failure on its own.
- Attach a descriptive `error` field so wedged-backend cases surface in the run JSON (`agent produced no step_finish events …`).

## Why

`run-zengram.sh` invokes `opencode-fork` with `... || { echo "[adapter] opencode-zengram exited non-zero, capturing partial results" >&2; }`. When the zengram backend wedges, opencode-fork exits non-zero, the OR-clause swallows it, the Python parser writes `{turns: 0, prompt_tokens: 0, …}`, and the harness stamps `status: "completed"`.

In **survey50_round7** (2026-05-06) this hid 14 of 50 zengram runs: the backend wedged on `dj-13794`, every subsequent zengram task returned in ~96 s with an empty patch but `"completed"` status. The phantoms then pass scoring (empty patch never applies → "not resolved") and silently inflate the denominator, attenuating any real signal.

This is the write-side counterpart to PR #11's read-side integrity gate — that gate catches *stale* scores; this catches *fake-completed* runs at the source.

## Test plan

- [x] Re-ran the 14 affected tasks (`tasks/round7_bad14.txt`) on the existing pinned dir; all 14 produced 3–15 turns with healthy token counts.
- [x] `bun harness/src/index.ts analyze` shows `Score integrity: ok (100 runs ↔ scores)` on the recovered round-7 dataset.
- [ ] If a future wedge happens, confirm the run JSON now carries `status: "failed"` and the descriptive `error` string.