### PR TITLE
fix(harness): kill child process group on timeout

### DIFF
--- a/harness/src/agent.ts
+++ b/harness/src/agent.ts
@@ -23,14 +23,49 @@
  *                       RunResult.trajectory to stay undefined)
  */
 
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { RunResult, SweTask, Trajectory, Variant } from "./types.js";
 
-const execFileAsync = promisify(execFile);
+// Run a child to completion, killing its entire process group on timeout.
+// `execFile`'s built-in timeout sends SIGTERM only to the immediate child,
+// which leaves grandchildren orphaned when the adapter is bash → exec bun
+// (round 9 dj-13033 wedged 8.5h past the 30-min cap this way). Putting the
+// child in its own process group via `detached: true` and SIGKILL'ing the
+// negative PID reaps every descendant regardless of how the wrapper handles
+// signals. The promise rejects with `Error("ETIMEDOUT")` so the existing
+// catch block in runAgent classifies the run as a timeout.
+function runWithTimeout(
+  cmd: string,
+  args: string[],
+  opts: { timeoutMs: number; env: NodeJS.ProcessEnv },
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      env:      opts.env,
+      detached: true,
+      stdio:    "ignore",
+    });
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      try { process.kill(-child.pid!, "SIGKILL"); } catch {}
+    }, opts.timeoutMs);
+    child.once("exit", (code, signal) => {
+      clearTimeout(timer);
+      if (timedOut)        return reject(new Error("ETIMEDOUT"));
+      if (signal)          return reject(new Error(`killed by ${signal}`));
+      if (code !== 0)      return reject(new Error(`exited with code ${code}`));
+      resolve();
+    });
+    child.once("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
 
 const AGENT_CMDS: Record<Variant, string> = {
   baseline: process.env["OPENCODE_BASELINE_CMD"] ?? "opencode",
@@ -97,7 +132,7 @@ Rules:
   };
 
   try {
-    await execFileAsync(
+    await runWithTimeout(
       cmd,
       [
         "run",
@@ -108,7 +143,7 @@ Rules:
         "--usage-json",       usageFile,
         "--trajectory-json",  trajFile,
       ],
-      { timeout: DEFAULT_TIMEOUT_MS, env: childEnv },
+      { timeoutMs: DEFAULT_TIMEOUT_MS, env: childEnv },
     );
 
     const duration_ms = Date.now() - start;

--- a/harness/src/agent.ts
+++ b/harness/src/agent.ts
@@ -32,11 +32,16 @@ import type { RunResult, SweTask, Trajectory, Variant } from "./types.js";
 // Run a child to completion, killing its entire process group on timeout.
 // `execFile`'s built-in timeout sends SIGTERM only to the immediate child,
 // which leaves grandchildren orphaned when the adapter is bash → exec bun
-// (round 9 dj-13033 wedged 8.5h past the 30-min cap this way). Putting the
-// child in its own process group via `detached: true` and SIGKILL'ing the
-// negative PID reaps every descendant regardless of how the wrapper handles
-// signals. The promise rejects with `Error("ETIMEDOUT")` so the existing
-// catch block in runAgent classifies the run as a timeout.
+// (a round 9 task wedged for hours past the configured timeout this way).
+// Putting the child in its own process group via `detached: true` and
+// SIGKILL'ing the negative PID reaps every descendant regardless of how
+// the wrapper handles signals. The promise rejects with `Error("ETIMEDOUT")`
+// so the existing catch block in runAgent classifies the run as a timeout.
+//
+// POSIX-only: `process.kill(-pid, ...)` is not supported on Windows. The
+// bench is Linux-only by design (llama.cpp / opencode-fork adapter chain),
+// but if that ever changes the negative-PID call will throw and we fall
+// back to a best-effort direct kill of the immediate child.
 function runWithTimeout(
   cmd: string,
   args: string[],
@@ -48,21 +53,38 @@ function runWithTimeout(
       detached: true,
       stdio:    "ignore",
     });
-    let timedOut = false;
+    let settled = false;
+    const settle = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      fn();
+    };
     const timer = setTimeout(() => {
-      timedOut = true;
-      try { process.kill(-child.pid!, "SIGKILL"); } catch {}
+      try {
+        process.kill(-child.pid!, "SIGKILL");
+      } catch {
+        // Negative-PID kill failed (e.g. Windows, or the group is already
+        // gone). Best-effort fallback to the immediate child — descendants
+        // may survive but at least the wrapper dies and the harness moves on.
+        try { child.kill("SIGKILL"); } catch {}
+      }
+      // Reject immediately rather than waiting for `exit`. If the SIGKILL
+      // doesn't take (unkillable state, permission error, non-POSIX platform
+      // where negative-PID isn't supported), waiting on `exit` would
+      // resurrect the wedge pathology this fix exists to prevent.
+      settle(() => reject(new Error("ETIMEDOUT")));
     }, opts.timeoutMs);
     child.once("exit", (code, signal) => {
       clearTimeout(timer);
-      if (timedOut)        return reject(new Error("ETIMEDOUT"));
-      if (signal)          return reject(new Error(`killed by ${signal}`));
-      if (code !== 0)      return reject(new Error(`exited with code ${code}`));
-      resolve();
+      settle(() => {
+        if (signal)     return reject(new Error(`killed by ${signal}`));
+        if (code !== 0) return reject(new Error(`exited with code ${code}`));
+        resolve();
+      });
     });
     child.once("error", (err) => {
       clearTimeout(timer);
-      reject(err);
+      settle(() => reject(err));
     });
   });
 }


### PR DESCRIPTION
## Summary
- Wrap child invocation with manual `spawn` + process-group kill so timeouts actually reap wedged subprocesses.
- Defense-in-depth half of PR #12: that one catches phantom *completions*; this one ensures the wrapper actually dies when the harness gives up.

## Why
Round 9 task 18 (dj-13033 zengram) wedged at 00:08 and was still alive at 08:40 — **8.5 hours past the 30-min `BENCH_TIMEOUT_MS`**. The harness was blocked on `await execFileAsync` because `execFile`'s built-in timeout only signals the immediate child (bash), and the bash → `exec bun` adapter chain leaves the bun grandchild orphaned. Manual `kill -TERM` to the bun PID was required to unblock.

PR #12 fixed the case where the wrapper *exits* with empty output (post-retry path of `run-zengram.sh`). It does nothing for the case where the wrapper itself never exits.

## Fix
Replace `execFileAsync` with a manual `spawn`:
- `detached: true` puts the child in its own process group.
- On timeout, `process.kill(-child.pid, "SIGKILL")` reaps the whole group, so it doesn't matter how each wrapper layer handles signals.
- Promise rejects with `Error("ETIMEDOUT")` so the existing catch in `runAgent` classifies the run as a timeout (not failed).

## Test plan
- [x] `tsc` clean
- [ ] Verify next round: any single-task wedge resolves at the 30-min cap (vs 8.5 h)
- [ ] No leftover bun grandchildren in `ps -ef` after a timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)